### PR TITLE
docs: clarify cache reuse

### DIFF
--- a/herb_rag_kit/scripts/run_dota.py
+++ b/herb_rag_kit/scripts/run_dota.py
@@ -1,5 +1,12 @@
-import os, sys
+import sys
+from pathlib import Path
+
+# Ensure the package is importable when running this script directly
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
 from herb_rag_kit.pipelines.run_method import main
+
 if __name__ == "__main__":
+    # Inject the fixed method argument and delegate to the shared runner
     sys.argv = [sys.argv[0], "--method", "dota"] + sys.argv[1:]
     main()

--- a/herb_rag_kit/scripts/run_dragin.py
+++ b/herb_rag_kit/scripts/run_dragin.py
@@ -1,6 +1,10 @@
 import sys
-sys.path.insert(0, "./src")
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
 from herb_rag_kit.pipelines.run_method import main
+
 if __name__ == "__main__":
     sys.argv = [sys.argv[0], "--method", "dragin"] + sys.argv[1:]
     main()

--- a/herb_rag_kit/scripts/run_graphrag.py
+++ b/herb_rag_kit/scripts/run_graphrag.py
@@ -1,6 +1,10 @@
 import sys
-sys.path.insert(0, "./src")
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
 from herb_rag_kit.pipelines.run_method import main
+
 if __name__ == "__main__":
     sys.argv = [sys.argv[0], "--method", "graphrag"] + sys.argv[1:]
     main()

--- a/herb_rag_kit/scripts/run_hdrag.py
+++ b/herb_rag_kit/scripts/run_hdrag.py
@@ -1,6 +1,10 @@
 import sys
-sys.path.insert(0, "./src")
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
 from herb_rag_kit.pipelines.run_method import main
+
 if __name__ == "__main__":
     sys.argv = [sys.argv[0], "--method", "hdrag"] + sys.argv[1:]
     main()


### PR DESCRIPTION
## Summary
- note run scripts auto-add `src` path and `PYTHONPATH` is only needed for direct module execution
- document that embedding cache reuses previous results and only embeds new docs

## Testing
- `python -m pytest`
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_e_6898e76e06808329b0e138e7f4f8a187